### PR TITLE
fix typo: 'flawing' to 'flowing'

### DIFF
--- a/src/epub/text/chapter-60.xhtml
+++ b/src/epub/text/chapter-60.xhtml
@@ -25,7 +25,7 @@
 			<p>Athos, who imagined that he saw him move, was the first to go up to him.</p>
 			<p>“Well?” inquired d’Artagnan.</p>
 			<p>“Well, if he is dead,” said Athos, “he has not been so long, for he is still warm. But no, his heart is beating. Ho, there, my friend!”</p>
-			<p>The wounded man heaved a sigh. D’Artagnan took some water in the hollow of his hand and threw it upon his face. The man opened his eyes, made an effort to raise his head, and fell back again. The wound was in the top of his skull and blood was flawing copiously.</p>
+			<p>The wounded man heaved a sigh. D’Artagnan took some water in the hollow of his hand and threw it upon his face. The man opened his eyes, made an effort to raise his head, and fell back again. The wound was in the top of his skull and blood was flowing copiously.</p>
 			<p>Aramis dipped a cloth into some water and applied it to the gash. Again the wounded man opened his eyes and looked in astonishment at these strangers, who appeared to pity him.</p>
 			<p>“You are among friends,” said Athos, in English; “so cheer up, and tell us, if you have the strength to do so, what has happened?”</p>
 			<p>“The king,” muttered the wounded man, “the king is a prisoner.”</p>


### PR DESCRIPTION
Gutenberg has this same transcription error, but the upstream scans at Google Books have it spelled this way (correctly).

https://books.google.com/books?id=EQUEAAAAYAAJ&pg=PA177#v=onepage&q&f=false